### PR TITLE
Fixes #13: :guest_cache_dir config should get its value from the synced folders hash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .idea/
 .vagrant/
+.vagrant-butcher/

--- a/lib/vagrant-butcher/action/auto_knife.rb
+++ b/lib/vagrant-butcher/action/auto_knife.rb
@@ -17,9 +17,8 @@ module Vagrant
         end
 
         def auto_create_knife(env)
-          folders = vm_config(env).synced_folders
-          if !folders.has_key?("/vagrant") || folders["/vagrant"][:disabled] == TRUE
-            env[:butcher].ui.warn "/vagrant folder not set to be mounted."
+          if !guest_cache_dir(env)
+            return false
           end
 
           unless File.exists?(cache_dir(env))
@@ -37,8 +36,6 @@ module Vagrant
 
           env[:butcher].ui.info "Copied #{guest_key_path(env)} to #{auto_knife_key_path(env)}"
 
-          env[:butcher].ui.info "Creating #{auto_knife_config_file(env)}"
-
           knife_rb = <<-END.gsub(/^ */, '')
             log_level                :info
             log_location             STDOUT
@@ -47,6 +44,8 @@ module Vagrant
           END
 
           File.new(auto_knife_config_file(env), 'w+').write(knife_rb)
+
+          env[:butcher].ui.success "Created #{auto_knife_config_file(env)}"
 
           return true
         end

--- a/lib/vagrant-butcher/config.rb
+++ b/lib/vagrant-butcher/config.rb
@@ -3,14 +3,12 @@ module Vagrant
     class Config < ::Vagrant.plugin('2', :config)
       attr_accessor :guest_key_path
       attr_accessor :cache_dir
-      attr_accessor :guest_cache_dir
       attr_accessor :knife_config_file
       
       def initialize
         super
         @guest_key_path = UNSET_VALUE
         @cache_dir = UNSET_VALUE
-        @guest_cache_dir = UNSET_VALUE
         @knife_config_file = UNSET_VALUE
       end
 
@@ -39,7 +37,6 @@ module Vagrant
       def finalize!
         @guest_key_path = '/etc/chef/client.pem' if @guest_key_path == UNSET_VALUE
         @cache_dir = File.expand_path ".vagrant-butcher" if @cache_dir == UNSET_VALUE
-        @guest_cache_dir = "/vagrant/" + File.basename(@cache_dir) if @guest_cache_dir == UNSET_VALUE
         @knife_config_file = File.expand_path "#{ENV['HOME']}/.chef/knife.rb" if @knife_config_file == UNSET_VALUE
       end
     end

--- a/lib/vagrant-butcher/version.rb
+++ b/lib/vagrant-butcher/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module Butcher
-    VERSION = "1.1.1"
+    VERSION = "2.0.0"
   end
 end

--- a/spec/unit/vagrant_butcher/config_spec.rb
+++ b/spec/unit/vagrant_butcher/config_spec.rb
@@ -15,10 +15,6 @@ describe Vagrant::Butcher::Config do
     subject.should respond_to(:cache_dir)
   end
   
-  it "has the option to set guest cache dir path" do
-    subject.should respond_to(:guest_cache_dir)
-  end
-  
   it "sets knife.rb default path" do
     subject.finalize!.should eql(File.expand_path("#{ENV['HOME']}/.chef/knife.rb"))
   end
@@ -31,11 +27,6 @@ describe Vagrant::Butcher::Config do
   it "sets cache dir default path" do
     subject.finalize!
     subject.cache_dir.should eql(File.expand_path(".vagrant-butcher"))
-  end
-  
-  it "sets guest cache dir default path" do
-    subject.finalize!
-    subject.guest_cache_dir.should eql("/vagrant/" + File.basename(subject.cache_dir))
   end
   
   describe "#validate" do


### PR DESCRIPTION
Other updates included are:
- Added default cache folder (.vagrant-butcher) to the gitignore
- Incremented the major version number to 2.0.0 since the removal of the
  guest_cache_dir is a non backwards compatible change.
- Updated the final info log to be a success message.
