### PR TITLE
fix .vagrant/butcher not existing in vagrant-aws

### DIFF
--- a/lib/vagrant-butcher/helpers/key_files.rb
+++ b/lib/vagrant-butcher/helpers/key_files.rb
@@ -64,7 +64,7 @@ module Vagrant
           create_cache_dir(env)
 
           begin
-            machine(env).communicate.execute "cp #{guest_key_path(env)} #{guest_cache_key_path(env)}", :sudo => true
+            machine(env).communicate.execute "mkdir -p #{guest_cache_key_path(env)} ; cp #{guest_key_path(env)} #{guest_cache_key_path(env)}", :sudo => true
             ui(env).info "Copied #{guest_key_path(env)} to #{guest_cache_key_path(env)}"
           rescue Exception => e
             ui(env).error "Failed to copy #{guest_key_path(env)} to #{guest_cache_key_path(env)}"


### PR DESCRIPTION
related to https://github.com/cassianoleal/vagrant-butcher/issues/31

Fixes the inital issue with `vagrant up/provision`.

Still gets this issue on `vagrant destroy` (related to the .pem not being copied):

```
Ridley::Client crashed!
Ridley::Errors::ClientKeyFileNotFoundOrInvalid: client key is invalid or not found at: '/Users/scalp/audax/cookbooks/zs-common/.vagrant/butcher/aws1-client.pem'
  /Users/scalp/.vagrant.d/gems/gems/ridley-1.5.3/lib/ridley/client.rb:156:in `initialize'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `public_send'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `dispatch'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1[Butcher] Chef client key not found at /Users/scalp/audax/cookbooks/zs-common/.vagrant/butcher/aws1-client.pem
[Butcher] Could not butcher node zs-common-scalp-vagrant-aws: undefined method `node' for nil:NilClass/lib/celluloid/calls.rb:67:in `dispatch'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1/lib/celluloid/actor.rb:326:in `block in handle_message'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1/lib/celluloid/tasks.rb:42:in `block in initialize'
  /Users/scalp/.vagrant.d/gems/gems/celluloid-0.14.1/lib/celluloid/tasks/task_fiber.rb:11:in `block in create'

[Butcher] Could not butcher client zs-common-scalp-vagrant-aws: undefined method `client' for nil:NilClass
[Butcher] ["node", "client"] not butchered from the Chef Server. Client key was left at /Users/scalp/audax/cookbooks/zs-common/.vagrant/butcher/aws1-client.pem
[aws1] Terminating the instance...
[zs1] VM not created. Moving on...
```
