### PR TITLE
Added support for the Vagrant 1.5 UI object

### DIFF
--- a/lib/vagrant-butcher/env.rb
+++ b/lib/vagrant-butcher/env.rb
@@ -4,7 +4,11 @@ module Vagrant
       attr_accessor :ui
 
       def initialize
-        if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new("1.2")
+        vagrant_version = Gem::Version.new(::Vagrant::VERSION)
+        if vagrant_version >= Gem::Version.new("1.5")
+          @ui = ::Vagrant::UI::Colored.new
+          @ui.opts[:target] = 'Butcher'
+        elsif vagrant_version >= Gem::Version.new("1.2")
           @ui = ::Vagrant::UI::Colored.new.scope('Butcher')
         else
           @ui = ::Vagrant::UI::Colored.new('Butcher')


### PR DESCRIPTION
Fixes #44

The UI object in Vagrant 1.5 takes no constructor arguments.
