### PR TITLE
Don't pass param to scope() with Vagrant::VERSION > 1.5

### DIFF
--- a/lib/vagrant-butcher/env.rb
+++ b/lib/vagrant-butcher/env.rb
@@ -4,12 +4,12 @@ module Vagrant
       attr_accessor :ui
 
       def initialize
-        vagrant_version = Gem::Version.new(::Vagrant::VERSION)
-        if vagrant_version >= Gem::Version.new("1.5")
-          @ui = ::Vagrant::UI::Colored.new
-          @ui.opts[:target] = 'Butcher'
-        elsif vagrant_version >= Gem::Version.new("1.2")
-          @ui = ::Vagrant::UI::Colored.new.scope('Butcher')
+        if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new("1.2")
+          if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new("1.5")
+             @ui = ::Vagrant::UI::Colored.new
+          else
+             @ui = ::Vagrant::UI::Colored.new.scope('Butcher')
+          end
         else
           @ui = ::Vagrant::UI::Colored.new('Butcher')
         end


### PR DESCRIPTION
vagrant-butcher breaks on my 1.5.2 installation.  Arguments to ::Vagrant::UI::Colored.new.scope() are no longer allowed.
