### PR TITLE
Don't write the key file if there is no data.

### DIFF
--- a/lib/vagrant-butcher/helpers/key_files.rb
+++ b/lib/vagrant-butcher/helpers/key_files.rb
@@ -32,7 +32,7 @@ module Vagrant
           create_cache_dir(env)
 
           machine(env).communicate.execute("cat #{guest_key_path(env)}", sudo: true) do |type,data|
-            File.open("#{cache_dir(env)}/#{key_filename(env)}", "w") { |f| f << data } if type == :stdout
+            File.open("#{cache_dir(env)}/#{key_filename(env)}", "w") { |f| f << data } if type == :stdout and not data.empty?
           end
 
           ui(env).info "Saved client key to #{cache_dir(env)}/#{key_filename(env)}"


### PR DESCRIPTION
The default-client.pem file is being immediately overwritten by a 0 byte file in my environment.  I'm still not sure why this block gets executed multiple times, but I've been using this patch to prevent it from happening.  
